### PR TITLE
Fixes #2

### DIFF
--- a/nsot_sync/drivers/simple.py
+++ b/nsot_sync/drivers/simple.py
@@ -96,7 +96,11 @@ class SimpleDriver(BaseDriver):
         then the single interface.
         '''
         families = netifaces.ifaddresses(ifname)
-        mac_addr = families[netifaces.AF_LINK][0]['addr']
+        try:
+            # Not all interfaces have AF_LINK
+            mac_addr = families[netifaces.AF_LINK][0]['addr']
+        except KeyError:
+            mac_addr = '00:00:00:00:00:00'
         networks = []
 
         for family, addrs in families.iteritems():

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-VERSION = '0.3'
+VERSION = '0.4'
 
 setup(
     name='nsot_sync',


### PR DESCRIPTION
Not every interface will have AF_LINK. If AF_LINK setting fails,
fall back to 00:00:00:00:00:00
