### PR TITLE
Fixes #13 and #15 by implementing specify interfaces and ignore list

### DIFF
--- a/nsot_sync/commands/simple.py
+++ b/nsot_sync/commands/simple.py
@@ -1,18 +1,27 @@
 from __future__ import print_function
 import click
 from nsot_sync.drivers import simple
+from nsot_sync.common import validate_csv
 
 
 @click.command()
+@click.option('-i', '--interfaces', callback=validate_csv, default=[],
+              help='Limit which interfaces, sep by comma, are synced')
+@click.option('-I', '--ignore-intfs', callback=validate_csv, default=[],
+              help='Ignore interfaces prefixed with these strings')
 @click.pass_context
-def cli(ctx):
+def cli(ctx, interfaces=[], ignore_intfs=[]):
     '''Simple driver uses system interfaces to generate NSoT resources
 
     No extra attributes are added to the resources other than linking them
     together
     '''
 
-    driver = simple.SimpleDriver(click_ctx=ctx)
+    driver = simple.SimpleDriver(
+        click_ctx=ctx,
+        limit_intfs=interfaces,
+        ignore_intfs=ignore_intfs,
+    )
     if ctx.obj['NOOP']:
         driver.noop()
         return

--- a/nsot_sync/common.py
+++ b/nsot_sync/common.py
@@ -12,3 +12,23 @@ def info(msg):
 
 def success(msg):
     click.secho('SUCCESS: %s' % msg, fg='green', err=True)
+
+
+def validate_csv(ctx, param, value):
+    '''List must be passed as comma separated values
+
+    Having spaces after the comma is fine:
+
+        eth0,eth1, eth2,eth3
+        eth,lo, docker,vpn
+    '''
+    import re
+
+    if not value:
+        return []
+
+    try:
+        ifnames = re.split(',|, ', value)
+        return ifnames
+    except:
+        raise click.BadParameter(validate_csv.__doc__)

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-VERSION = '0.4.6'
+VERSION = '0.4.7'
 
 setup(
     name='nsot_sync',


### PR DESCRIPTION
``` bash
$ nsot_sync --noop simple  | jq  '."interfaces"[]."name"' 
"wlp2s0"

$ nsot_sync --noop simple -i docker0,lo | jq  '."interfaces"[]."name"'
"lo"
"docker0"

$ nsot_sync --noop simple -I docker0,wlp2s0 | jq  '."interfaces"[]."name"'
"lo"
```
